### PR TITLE
chore: split test and PR comment workflows

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  build-and-deploy-dev:
     runs-on: ubuntu-latest
     steps:
       - name: Build

--- a/.github/workflows/build-stage.yml
+++ b/.github/workflows/build-stage.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-stage:
     runs-on: ubuntu-latest
     steps:
       - name: Build

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  deploy-prod:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  deploy-stage:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -8,9 +8,7 @@ jobs:
   handle-command:
     if: github.event.issue.pull_request
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    permissions: write-all
 
     steps:
       - name: Trigger based on comment

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,4 +1,4 @@
-name: Test and Post CI/CD Instructions on PR
+name: Post CI/CD Instructions on PR
 
 on:
   pull_request:
@@ -6,26 +6,9 @@ on:
     types: [opened]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    outputs:
-      tests_passed: ${{ steps.run-tests.outcome == 'success' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - name: Install dependencies
-        run: npm ci
-      - id: run-tests
-        name: Run tests
-        run: npm test
-
   comment-guide:
     runs-on: ubuntu-latest
     permissions: write-all
-    needs: test
     steps:
       - name: Post CI/CD trigger guide
         uses: actions/github-script@v6
@@ -39,13 +22,13 @@ jobs:
               body: `
                 👋 To complete the CI/CD pipeline, please comment the following commands in sequence:
 
-                1. \"merge & build and deploy for development\"
-                2. \"merge & build for staging\"
-                3. \"merge & deploy for staging\"
-                4. \"merge & deploy for production\"
+                1. \`merge & build and deploy for development\`
+                2. \`merge & build for staging\`
+                3. \`merge & deploy for staging\`
+                4. \`merge & deploy for production\`
 
                 Each comment will trigger a corresponding GitHub Actions workflow. 
-                
+            
                 All steps must be completed before merging! 
                 `
             });

--- a/.github/workflows/unit-test-on-push.yml
+++ b/.github/workflows/unit-test-on-push.yml
@@ -1,0 +1,24 @@
+name: Run Unit Tests
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
- Moved `npm test` to a dedicated `run-tests.yml` triggered on all branch pushes
- Separated CI/CD guide comment into its own workflow triggered on PRs to `main`
- Simplifies logic and improves clarity between test and deployment steps

Closes #7 