### PR TITLE
feat: handle env-specific behavior in PR comment workflow

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,0 +1,37 @@
+name: Close Issue on Branch Deletion
+
+on:
+  delete:
+    branches:
+      - 'feature/issue-*'
+
+jobs:
+  close-linked-issue:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.ref, 'feature/issue-')
+
+    permissions: write-all
+    steps:
+      - name: Extract issue number and close it
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = context.payload.ref; // e.g., 'feature/issue-11'
+            const match = branch.match(/^feature\/issue-(\d+)$/);
+
+            if (!match) {
+              console.log("Branch name doesn't match pattern. Skipping.");
+              return;
+            }
+
+            const issueNumber = parseInt(match[1], 10);
+
+            console.log(`Closing issue #${issueNumber} linked to deleted branch '${branch}'`);
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              state: "closed"
+            });

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -17,22 +17,27 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const comment = context.payload.comment.body.trim().toLowerCase();
+
             const commands = {
               "merge & build and deploy for development": {
                 base: "development",
-                workflow: "build-and-deploy-dev.yml"
+                workflow: "build-and-deploy-dev.yml",
+                merge: true
               },
               "merge & build for staging": {
                 base: "stage",
-                workflow: "build-stage.yml"
+                workflow: "build-stage.yml",
+                merge: true
               },
-              "merge & deploy for staging": {
+              "deploy for staging": {
                 base: "stage",
-                workflow: "deploy-stage.yml"
+                workflow: "deploy-stage.yml",
+                merge: false
               },
-              "merge & deploy for production": {
+              "deploy for production": {
                 base: "main",
-                workflow: "deploy-prod.yml"
+                workflow: "deploy-prod.yml",
+                merge: false
               }
             };
 
@@ -43,7 +48,6 @@ jobs:
             }
 
             const { repo, owner } = context.repo;
-            const pr = context.payload.issue.pull_request;
             const prNumber = context.payload.issue.number;
 
             const { data: prData } = await github.rest.pulls.get({
@@ -55,35 +59,34 @@ jobs:
             const sourceBranch = prData.head.ref;
             const targetBranch = config.base;
 
-            // Create a new PR from feature branch to target
-            const title = `Auto-merge ${sourceBranch} -> ${targetBranch}`;
-            const branchRef = `${sourceBranch}-to-${targetBranch}`;
+            if (config.merge) {
+              const title = `Auto-merge ${sourceBranch} -> ${targetBranch}`;
+              try {
+                const { data: newPR } = await github.rest.pulls.create({
+                  owner,
+                  repo,
+                  title,
+                  head: sourceBranch,
+                  base: targetBranch,
+                  body: `Automated merge for ${comment}`
+                });
 
-            try {
-              const { data: newPR } = await github.rest.pulls.create({
-                owner,
-                repo,
-                title,
-                head: sourceBranch,
-                base: targetBranch,
-                body: `Automated merge for ${comment}`
-              });
+                await github.rest.pulls.merge({
+                  owner,
+                  repo,
+                  pull_number: newPR.number,
+                  merge_method: "squash"
+                });
 
-              // Merge it
-              await github.rest.pulls.merge({
-                owner,
-                repo,
-                pull_number: newPR.number,
-                merge_method: "squash"
-              });
-
-              console.log(`Merged ${sourceBranch} into ${targetBranch}`);
-            } catch (err) {
-              console.log("PR may already exist or merge failed:", err.message);
-              return;
+                console.log(`Merged ${sourceBranch} into ${targetBranch}`);
+              } catch (err) {
+                console.log("PR may already exist or merge failed:", err.message);
+                // Optionally you can exit here by uncommenting the next line:
+                // return;
+              }
             }
 
-            // Trigger corresponding workflow on base branch
+            // Trigger the workflow regardless of merge success or if no merge required
             await github.rest.actions.createWorkflowDispatch({
               owner,
               repo,

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -22,10 +22,10 @@ jobs:
               body: `
                 👋 To complete the CI/CD pipeline, please comment the following commands in sequence:
 
-                1. \`merge & build and deploy for development\`
-                2. \`merge & build for staging\`
-                3. \`merge & deploy for staging\`
-                4. \`merge & deploy for production\`
+                1. merge & build and deploy for development
+                2. merge & build for staging
+                3. deploy for staging
+                4. deploy for production
 
                 Each comment will trigger a corresponding GitHub Actions workflow. 
             


### PR DESCRIPTION
- Added `merge` flag to each command in the handler map
- Only run merge logic for "merge & build" commands (development, staging)
- Skip merge for "deploy" commands (staging, production)
- Trigger corresponding workflow based on environment and command
- Improved logs for clarity on merge vs. deploy steps

closes #19 